### PR TITLE
Update valve.py creating new class for windows/gate valves with 2 setpoints

### DIFF
--- a/pcdsdevices/valve.py
+++ b/pcdsdevices/valve.py
@@ -248,6 +248,14 @@ class VGC(VRC):
                                       doc='Downstream vacuum device used for'
                                       'interlocking this valve')
 
+    class VGC_2S(VGC):
+    """Class for Controlled Gate Valves with 2 setpoints."""
+    at_vac_setpoint_ds = Cpt(EpicsSignalWithRBV, ':AT_VAC_SP_DS', kind='config',
+                          doc='AT VAC Set point value for the downstream gauge')
+    setpoint_hysterisis_ds = Cpt(EpicsSignalWithRBV, ':AT_VAC_HYS_DS', kind='config',
+                              doc='AT VAC Hysterisis for the downstream setpoint')
+    
+    
 
 class VFS(Device, LightpathMixin):
     """Class for Fast Shutter Valve."""


### PR DESCRIPTION

## Description
Update valve.py creating new class for windows/gate valves with 2 setpoints. This class extends the VGC class and includes the additional setpoint and hysteresis

## Motivation and Context
In TMO there is a requirement to interlock beam line valves with 2 different setpoints, instead of the standard 1 setpoint.

